### PR TITLE
Allowing for spaces in key names which is legal.

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1,7 +1,7 @@
 /* Nano Templates (Tomasz Mazur, Jacek Becela) */
 
 function nano(template, data) {
-  return template.replace(/\{([\w\.]*)\}/g, function(str, key) {
+  return template.replace(/\{([\w\.\s]*)\}/g, function(str, key) {
     var keys = key.split("."), v = data[keys.shift()];
     for (var i = 0, l = keys.length; i < l; i++) v = v[keys[i]];
     return (typeof v !== "undefined" && v !== null) ? v : "";


### PR DESCRIPTION
Had a case where returned JSON object contains keys with spaces, this legal in JS; perhaps even allowing for any characters would be a good idea: http://stackoverflow.com/questions/8676011/illegal-characters-in-object-or-json-key
